### PR TITLE
카카오 로그인 WIP

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "react": "^18.1.0",
     "react-dom": "^18.1.0",
     "react-router-dom": "^6.3.0",
+    "recoil": "^0.7.5",
     "styled-components": "^5.3.5",
     "styled-reset": "^4.4.2"
   },
@@ -25,6 +26,7 @@
     "@types/react": "^18.0.9",
     "@types/react-dom": "^18.0.5",
     "@types/react-router-dom": "^5.3.3",
+    "@types/recoil": "^0.0.9",
     "@types/styled-components": "^5.1.26",
     "@typescript-eslint/eslint-plugin": "^5.26.0",
     "@typescript-eslint/parser": "^5.26.0",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "styled-reset": "^4.4.2"
   },
   "devDependencies": {
+    "@types/node": "^18.7.14",
     "@types/react": "^18.0.9",
     "@types/react-dom": "^18.0.5",
     "@types/react-router-dom": "^5.3.3",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,13 +2,16 @@ import Router from "@/components/Router";
 import { ThemeProvider } from "styled-components";
 import { GlobalStyle } from "@/styles/global-style";
 import { theme } from "@/styles/theme";
+import { RecoilRoot } from "recoil";
 
 function App() {
   return (
     <>
       <GlobalStyle />
       <ThemeProvider theme={theme}>
-        <Router />
+        <RecoilRoot>
+          <Router />
+        </RecoilRoot>
       </ThemeProvider>
     </>
   );

--- a/src/api/authService.ts
+++ b/src/api/authService.ts
@@ -1,0 +1,8 @@
+const authService = {
+  kakaoLogin() {
+    console.log("카카오");
+    return;
+  },
+};
+
+export default authService;

--- a/src/api/authService.ts
+++ b/src/api/authService.ts
@@ -1,9 +1,9 @@
-import { URL } from "@/constants/index";
+import { METHOD } from "@/constants/index";
+import fetcher from "@/api/fetcher";
 
 const authService = {
-  kakaoLogin() {
-    console.log(URL.KAKAO_AUTH);
-    return;
+  kakaoLogin(code: string | null) {
+    return fetcher(METHOD.GET, `/auth/kakao?code=${code}`);
   },
 };
 

--- a/src/api/authService.ts
+++ b/src/api/authService.ts
@@ -1,6 +1,8 @@
+import { URL } from "@/constants/index";
+
 const authService = {
   kakaoLogin() {
-    console.log("카카오");
+    console.log(URL.KAKAO_AUTH);
     return;
   },
 };

--- a/src/api/fetcher.ts
+++ b/src/api/fetcher.ts
@@ -1,6 +1,7 @@
 import axios from "axios";
+import { URL } from "@/constants/index";
 
-axios.defaults.baseURL = "http://localhost:8000";
+axios.defaults.baseURL = URL.BASE;
 
 const fetcher = async (
   method: "get" | "post" | "put" | "delete",

--- a/src/api/fetcher.ts
+++ b/src/api/fetcher.ts
@@ -1,5 +1,5 @@
 import axios from "axios";
-import { URL } from "@/constants/index";
+import { URL, MESSAGE } from "@/constants/index";
 
 axios.defaults.baseURL = URL.BASE;
 
@@ -8,8 +8,12 @@ const fetcher = async (
   url: string,
   ...rest: { [key: string]: any }[]
 ) => {
-  const res = await axios[method](url, ...rest);
-  return res.data;
+  try {
+    const res = await axios[method](url, ...rest);
+    return res.data;
+  } catch (error: any) {
+    alert(`${MESSAGE.ALERT_API} (${error.message})`);
+  }
 };
 
 export default fetcher;

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -1,0 +1,1 @@
+export { default as authService } from "@/api/authService";

--- a/src/components/Router.tsx
+++ b/src/components/Router.tsx
@@ -13,7 +13,7 @@ const Router = () => {
       <Suspense fallback={<></>}>
         <Routes>
           <Route path='/' element={isLoggedIn.auth ? <Home /> : <Auth />} />
-          <Route path='*' element={<Navigate to='/' replace />} />
+          {/* <Route path='*' element={<Navigate to='/' replace />} /> */}
         </Routes>
       </Suspense>
     </BrowserRouter>

--- a/src/components/Router.tsx
+++ b/src/components/Router.tsx
@@ -2,18 +2,20 @@ import { BrowserRouter, Routes, Route, Navigate } from "react-router-dom";
 import { Suspense, lazy } from "react";
 import { useRecoilValue } from "recoil";
 import { userState } from "@/state/user";
+import { Kakao } from "@/components/auth";
 
 const Home = lazy(() => import("@/pages/Home"));
 const Auth = lazy(() => import("@/pages/Auth"));
 
 const Router = () => {
-  const isLoggedIn = useRecoilValue(userState);
+  const isLoggedIn = useRecoilValue(userState).auth;
   return (
     <BrowserRouter>
       <Suspense fallback={<></>}>
         <Routes>
-          <Route path='/' element={isLoggedIn.auth ? <Home /> : <Auth />} />
-          {/* <Route path='*' element={<Navigate to='/' replace />} /> */}
+          <Route path='/' element={isLoggedIn ? <Home /> : <Auth />} />
+          <Route path='/auth/kakao/*' element={!isLoggedIn && <Kakao />}></Route>
+          <Route path='*' element={<Navigate to='/' replace />} />
         </Routes>
       </Suspense>
     </BrowserRouter>

--- a/src/components/Router.tsx
+++ b/src/components/Router.tsx
@@ -1,25 +1,18 @@
 import { BrowserRouter, Routes, Route, Navigate } from "react-router-dom";
-import { Suspense, lazy, useState } from "react";
+import { Suspense, lazy } from "react";
+import { useRecoilValue } from "recoil";
+import { userState } from "@/state/user";
 
 const Home = lazy(() => import("@/pages/Home"));
 const Auth = lazy(() => import("@/pages/Auth"));
 
 const Router = () => {
-  const [isLoggedIn, setIsLoggedIn] = useState(false);
+  const isLoggedIn = useRecoilValue(userState);
   return (
     <BrowserRouter>
       <Suspense fallback={<></>}>
         <Routes>
-          <Route
-            path='/'
-            element={
-              isLoggedIn ? (
-                <Home setIsLoggedIn={setIsLoggedIn} />
-              ) : (
-                <Auth setIsLoggedIn={setIsLoggedIn} />
-              )
-            }
-          />
+          <Route path='/' element={isLoggedIn.auth ? <Home /> : <Auth />} />
           <Route path='*' element={<Navigate to='/' replace />} />
         </Routes>
       </Suspense>

--- a/src/components/auth/Kakao.tsx
+++ b/src/components/auth/Kakao.tsx
@@ -1,0 +1,25 @@
+import { authService } from "@/api";
+import { userState } from "@/state/user";
+import { useEffect } from "react";
+import { useNavigate } from "react-router-dom";
+import { useSetRecoilState } from "recoil";
+
+const Kakao = () => {
+  const code = new URL(document.URL).searchParams.get("code");
+  const setUserState = useSetRecoilState(userState);
+  const navigate = useNavigate();
+
+  const getToken = async () => {
+    const token = await authService.kakaoLogin(code);
+    setUserState({ auth: true, token: token });
+    navigate("/");
+  };
+
+  useEffect(() => {
+    getToken();
+  }, []);
+
+  return <>Kakao</>;
+};
+
+export default Kakao;

--- a/src/components/auth/index.ts
+++ b/src/components/auth/index.ts
@@ -1,0 +1,1 @@
+export { default as Kakao } from "@/components/auth/Kakao";

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -11,3 +11,7 @@ export const METHOD = Object.freeze({
   PUT: "put",
   DELETE: "delete",
 });
+
+export const MESSAGE = Object.freeze({
+  ALERT_API: "에러가 발생했습니다.",
+});

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -1,3 +1,10 @@
+export const URL = {
+  BASE: "http://localhost:8000",
+  KAKAO_AUTH: `https://kauth.kakao.com/oauth/authorize?client_id=${
+    import.meta.env.VITE_REST_API_KEY
+  }&redirect_uri=${import.meta.env.VITE_REDIRECT_URI}&response_type=code`,
+};
+
 export const METHOD = Object.freeze({
   GET: "get",
   POST: "post",

--- a/src/pages/Auth.tsx
+++ b/src/pages/Auth.tsx
@@ -1,10 +1,12 @@
-import { Dispatch, SetStateAction } from "react";
 import { authService } from "@/api";
+import { userState } from "@/state/user";
+import { useSetRecoilState } from "recoil";
 
-const Auth = ({ setIsLoggedIn }: { setIsLoggedIn: Dispatch<SetStateAction<boolean>> }) => {
+const Auth = () => {
+  const setIsLoggedIn = useSetRecoilState(userState);
   return (
     <>
-      <button onClick={() => setIsLoggedIn(true)}>Login</button>
+      <button onClick={() => setIsLoggedIn({ auth: true })}>Login</button>
       <button onClick={() => authService.kakaoLogin()}>카카오 로그인</button>
     </>
   );

--- a/src/pages/Auth.tsx
+++ b/src/pages/Auth.tsx
@@ -1,13 +1,13 @@
-import { authService } from "@/api";
 import { userState } from "@/state/user";
 import { useSetRecoilState } from "recoil";
+import { URL } from "@/constants";
 
 const Auth = () => {
   const setIsLoggedIn = useSetRecoilState(userState);
   return (
     <>
       <button onClick={() => setIsLoggedIn({ auth: true })}>Login</button>
-      <button onClick={() => authService.kakaoLogin()}>카카오 로그인</button>
+      <a href={URL.KAKAO_AUTH}>카카오 로그인</a>
     </>
   );
 };

--- a/src/pages/Auth.tsx
+++ b/src/pages/Auth.tsx
@@ -1,12 +1,8 @@
-import { userState } from "@/state/user";
-import { useSetRecoilState } from "recoil";
 import { URL } from "@/constants";
 
 const Auth = () => {
-  const setIsLoggedIn = useSetRecoilState(userState);
   return (
     <>
-      <button onClick={() => setIsLoggedIn({ auth: true })}>Login</button>
       <a href={URL.KAKAO_AUTH}>카카오 로그인</a>
     </>
   );

--- a/src/pages/Auth.tsx
+++ b/src/pages/Auth.tsx
@@ -1,7 +1,13 @@
 import { Dispatch, SetStateAction } from "react";
+import { authService } from "@/api";
 
 const Auth = ({ setIsLoggedIn }: { setIsLoggedIn: Dispatch<SetStateAction<boolean>> }) => {
-  return <button onClick={() => setIsLoggedIn(true)}>Login</button>;
+  return (
+    <>
+      <button onClick={() => setIsLoggedIn(true)}>Login</button>
+      <button onClick={() => authService.kakaoLogin()}>카카오 로그인</button>
+    </>
+  );
 };
 
 export default Auth;

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,7 +1,9 @@
-import { Dispatch, SetStateAction } from "react";
+import { userState } from "@/state/user";
+import { useSetRecoilState } from "recoil";
 
-const Home = ({ setIsLoggedIn }: { setIsLoggedIn: Dispatch<SetStateAction<boolean>> }) => {
-  return <button onClick={() => setIsLoggedIn(false)}>Logout</button>;
+const Home = () => {
+  const setIsLoggedIn = useSetRecoilState(userState);
+  return <button onClick={() => setIsLoggedIn({ auth: false })}>Logout</button>;
 };
 
 export default Home;

--- a/src/state/user.ts
+++ b/src/state/user.ts
@@ -2,5 +2,5 @@ import { atom } from "recoil";
 
 export const userState = atom({
   key: "userState",
-  default: { auth: false },
+  default: { auth: false, token: "" },
 });

--- a/src/state/user.ts
+++ b/src/state/user.ts
@@ -1,0 +1,6 @@
+import { atom } from "recoil";
+
+export const userState = atom({
+  key: "userState",
+  default: { auth: false },
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -571,6 +571,13 @@
     "@types/scheduler" "*"
     csstype "^3.0.2"
 
+"@types/recoil@^0.0.9":
+  version "0.0.9"
+  resolved "https://registry.yarnpkg.com/@types/recoil/-/recoil-0.0.9.tgz#a5efceda791ee2720418e232445bb34f4f2e4be9"
+  integrity sha512-dXKcvdzQbkFCcULgxhtc/3shoCNqsspRUY1KwIUYcAzgS0qY7+IxlcjRjq+9PizFnzKrHESllkbezqCMstPmQA==
+  dependencies:
+    recoil "*"
+
 "@types/scheduler@*":
   version "0.16.2"
   resolved "https://registry.yarnpkg.com/@types/scheduler/-/scheduler-0.16.2.tgz#1a62f89525723dde24ba1b01b092bf5df8ad4d39"
@@ -1727,6 +1734,11 @@ globrex@^0.1.2:
   resolved "https://registry.yarnpkg.com/globrex/-/globrex-0.1.2.tgz#dd5d9ec826232730cd6793a5e33a9302985e6098"
   integrity sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==
 
+hamt_plus@1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/hamt_plus/-/hamt_plus-1.0.2.tgz#e21c252968c7e33b20f6a1b094cd85787a265601"
+  integrity sha512-t2JXKaehnMb9paaYA7J0BX8QQAY8lwfQ9Gjf4pg/mk4krt+cmwmU652HOoWonf+7+EQV97ARPMhhVgU1ra2GhA==
+
 has-bigints@^1.0.1, has-bigints@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/has-bigints/-/has-bigints-1.0.2.tgz#0871bd3e3d51626f6ca0966668ba35d5602d6eaa"
@@ -2457,6 +2469,13 @@ react@^18.1.0:
   integrity sha512-4oL8ivCz5ZEPyclFQXaNksK3adutVS8l2xzZU0cqEFrE9Sb7fC0EFK5uEk74wIreL1DERyjvsU915j1pcT2uEQ==
   dependencies:
     loose-envify "^1.1.0"
+
+recoil@*, recoil@^0.7.5:
+  version "0.7.5"
+  resolved "https://registry.yarnpkg.com/recoil/-/recoil-0.7.5.tgz#9a33a03350cfd99e08bdd5b73bfc8b8b9ee751b9"
+  integrity sha512-GVShsj5+M/2GULWBs5WBJGcsNis/d3YvDiaKjYh3mLKXftjtmk9kfaQ8jwjoIXySCwn8/RhgJ4Sshwgzj2UpFA==
+  dependencies:
+    hamt_plus "1.0.2"
 
 recrawl-sync@^2.0.3:
   version "2.2.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -533,6 +533,11 @@
   resolved "https://registry.yarnpkg.com/@types/json5/-/json5-0.0.29.tgz#ee28707ae94e11d2b827bcbe5270bcea7f3e71ee"
   integrity sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==
 
+"@types/node@^18.7.14":
+  version "18.7.14"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.7.14.tgz#0fe081752a3333392d00586d815485a17c2cf3c9"
+  integrity sha512-6bbDaETVi8oyIARulOE9qF1/Qdi/23z6emrUh0fNJRUmjznqrixD4MpGDdgOFk5Xb0m2H6Xu42JGdvAxaJR/wA==
+
 "@types/prop-types@*":
   version "15.7.5"
   resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.5.tgz#5f19d2b85a98e9558036f6a3cacc8819420f05cf"


### PR DESCRIPTION
## 📋 Detail

- [x] Recoil 세팅
- [x] 인가코드 요청
- [x] 토큰 받아오기

## 📌 PR Point

- user 상태를 Recoil로 관리하도록 리팩토링했습니다
- 카카오에서 인가코드를 받아와 백엔드로 전송하는 부분까지 구현했습니다
-  인가코드를 백엔드로 보낼 때는 post 방식이 아닌 쿼리 스트링으로 보내줘야 한다고 합니다! 다음과 같이 갈텐데 인가 코드로 토큰 받아와서 반환해 주시면 될 것 같습니다 (아래 사진의 3 ~ 4번)

```
`/auth/kakao?code=${code}` // GET
```

![image](https://user-images.githubusercontent.com/61545957/188075194-35ffa181-feb6-4dd3-a28c-3094df2297e9.png)

## 📚 Reference

- [[React] 카카오 로그인 구현하기 - REST API](https://velog.io/@isabel_noh/React-%EC%B9%B4%EC%B9%B4%EC%98%A4-%EB%A1%9C%EA%B7%B8%EC%9D%B8-%EA%B5%AC%ED%98%84%ED%95%98%EA%B8%B0-REST-API)
