### PR TITLE
초기 세팅 6

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2022 HUFcus-Focus
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,7 +3,7 @@ import { ThemeProvider } from "styled-components";
 import { GlobalStyle } from "@/styles/global-style";
 import { theme } from "@/styles/theme";
 import { RecoilRoot } from "recoil";
-import { DebugObserver } from "@/components/common";
+import { DebugObserver, AppLayout } from "@/components/common";
 
 function App() {
   return (
@@ -12,7 +12,9 @@ function App() {
       <ThemeProvider theme={theme}>
         <RecoilRoot>
           <DebugObserver />
-          <Router />
+          <AppLayout>
+            <Router />
+          </AppLayout>
         </RecoilRoot>
       </ThemeProvider>
     </>

--- a/src/components/auth/Kakao.tsx
+++ b/src/components/auth/Kakao.tsx
@@ -1,4 +1,4 @@
-import { authService } from "@/shared/api";
+import { authApi } from "@/shared/api";
 import { userState } from "@/shared/state/user";
 import { useEffect } from "react";
 import { useNavigate } from "react-router-dom";
@@ -10,7 +10,7 @@ const Kakao = () => {
   const navigate = useNavigate();
 
   const getToken = async () => {
-    const token: string = await authService.kakaoLogin(code);
+    const token: string = await authApi.getKakaoToken(code);
     setUser({ ...user, token: token });
     navigate("/");
   };

--- a/src/components/common/AppLayout.tsx
+++ b/src/components/common/AppLayout.tsx
@@ -1,0 +1,32 @@
+import styled from "styled-components";
+import { media } from "@/styles/theme";
+
+const AppLayout = ({ children }: { children: JSX.Element }) => {
+  return (
+    <Wrapper>
+      <AppContainer>{children}</AppContainer>
+    </Wrapper>
+  );
+};
+
+export default AppLayout;
+
+const Wrapper = styled.div`
+  width: 100vw;
+  height: 100vh;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+`;
+
+const AppContainer = styled.div`
+  width: 375px;
+  height: 812px;
+  box-shadow: 0 0 2rem 0.1rem rgba(0, 0, 0, 0.2);
+  ${media.mobile} {
+    width: 100vw;
+    height: 100vh;
+    margin: 0;
+    box-shadow: none;
+  }
+`;

--- a/src/components/common/index.ts
+++ b/src/components/common/index.ts
@@ -1,1 +1,2 @@
 export { default as DebugObserver } from "@/components/common/DebugObserver";
+export { default as AppLayout } from "@/components/common/AppLayout";

--- a/src/shared/api/authApi.ts
+++ b/src/shared/api/authApi.ts
@@ -1,10 +1,10 @@
 import { METHOD } from "@/shared/constants/index";
 import fetcher from "@/shared/api/fetcher";
 
-const authService = {
-  kakaoLogin(code: string) {
+const authApi = {
+  getKakaoToken(code: string) {
     return fetcher(METHOD.GET, `/auth/kakao?code=${code}`);
   },
 };
 
-export default authService;
+export default authApi;

--- a/src/shared/api/index.ts
+++ b/src/shared/api/index.ts
@@ -1,1 +1,1 @@
-export { default as authService } from "@/shared/api/authService";
+export { default as authApi } from "@/shared/api/authApi";

--- a/src/styles/styled.d.ts
+++ b/src/styles/styled.d.ts
@@ -2,6 +2,13 @@ import "styled-components";
 
 declare module "styled-components" {
   export interface DefaultTheme {
-    color: { [key: string]: string };
+    color: {
+      green: "#adea97";
+      blue: "#7c9bfb";
+      yellow: "#ffefb0";
+      pink: "#f3b2b2";
+      brown: "#c1b097";
+      white: "#ffffff";
+    };
   }
 }

--- a/src/styles/theme.ts
+++ b/src/styles/theme.ts
@@ -2,7 +2,12 @@ import { DefaultTheme } from "styled-components";
 
 export const theme: DefaultTheme = {
   color: {
-    primary: "#222222",
+    green: "#adea97",
+    blue: "#7c9bfb",
+    yellow: "#ffefb0",
+    pink: "#f3b2b2",
+    brown: "#c1b097",
+    white: "#ffffff",
   },
 };
 


### PR DESCRIPTION
## 📋 Detail

- [x] 웹앱 레이아웃
- [x] 컬러 팔레트 추가
- [x] 라이센스 추가

## 📌 PR Point

- PC 환경에 웹앱 레이아웃을 적용했습니다 (스크린샷 참고)
- 사용할 색상들을 `theme` 파일에 정리했습니다. 다음과 같이 사용합니다
```
color: ${({ theme }) => theme.color.green};
```
- MIT 라이센스를 추가했습니다

## 👀 Screenshot / GIF
![image](https://user-images.githubusercontent.com/61545957/189346593-7a44d326-da0c-47e6-84ac-1732791d8f74.png)
