### PR TITLE
서버로 카카오 토큰 전송하는 방식으로 변경

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -17,7 +17,15 @@
     "ecmaVersion": "latest",
     "sourceType": "module"
   },
-  "plugins": ["react", "@typescript-eslint", "import", "jsx-a11y", "react-hooks", "prettier"],
+  "plugins": [
+    "react",
+    "@typescript-eslint",
+    "import",
+    "jsx-a11y",
+    "react-hooks",
+    "prettier",
+    "simple-import-sort"
+  ],
   "rules": {
     "@typescript-eslint/no-explicit-any": "off",
     "@typescript-eslint/no-non-null-assertion": "off",
@@ -39,7 +47,9 @@
         "endOfLine": "auto",
         "singleQuote": false
       }
-    ]
+    ],
+    "simple-import-sort/imports": "error",
+    "simple-import-sort/exports": "error"
   },
   "settings": {
     "react": {

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "eslint-plugin-prettier": "^4.0.0",
     "eslint-plugin-react": "^7.30.0",
     "eslint-plugin-react-hooks": "^4.5.0",
+    "eslint-plugin-simple-import-sort": "^8.0.0",
     "husky": "^8.0.1",
     "lint-staged": "^13.0.3",
     "prettier": "^2.6.2",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,9 +1,10 @@
-import Router from "@/components/Router";
+import { RecoilRoot } from "recoil";
 import { ThemeProvider } from "styled-components";
+
+import { AppLayout, DebugObserver } from "@/components/common";
+import Router from "@/components/Router";
 import { GlobalStyle } from "@/styles/global-style";
 import { theme } from "@/styles/theme";
-import { RecoilRoot } from "recoil";
-import { DebugObserver, AppLayout } from "@/components/common";
 
 function App() {
   return (

--- a/src/components/Router.tsx
+++ b/src/components/Router.tsx
@@ -1,8 +1,9 @@
-import { BrowserRouter, Routes, Route, Navigate } from "react-router-dom";
-import { Suspense, lazy } from "react";
+import { lazy, Suspense } from "react";
+import { BrowserRouter, Navigate, Route, Routes } from "react-router-dom";
 import { useRecoilValue } from "recoil";
-import { userState } from "@/shared/state/user";
+
 import { Kakao } from "@/components/auth";
+import { userState } from "@/shared/state/user";
 
 const Home = lazy(() => import("@/pages/Home"));
 const Auth = lazy(() => import("@/pages/Auth"));

--- a/src/components/auth/Kakao.tsx
+++ b/src/components/auth/Kakao.tsx
@@ -11,8 +11,8 @@ const Kakao = () => {
   const navigate = useNavigate();
 
   const kakaoLogin = async () => {
-    const token: string = await authApi.getKakaoToken(code);
-    setUser({ ...user, token: token });
+    const kakaoToken = await authApi.getKakaoToken(code);
+    setUser({ ...user, token: kakaoToken.access_token });
     navigate("/");
   };
 

--- a/src/components/auth/Kakao.tsx
+++ b/src/components/auth/Kakao.tsx
@@ -12,7 +12,9 @@ const Kakao = () => {
 
   const kakaoLogin = async () => {
     const kakaoToken = await authApi.getKakaoToken(code);
-    setUser({ ...user, token: kakaoToken.access_token });
+    console.log(kakaoToken.access_token);
+    const serviceToken = await authApi.getserviceToken(kakaoToken.access_token);
+    setUser({ ...user, token: serviceToken });
     navigate("/");
   };
 

--- a/src/components/auth/Kakao.tsx
+++ b/src/components/auth/Kakao.tsx
@@ -1,22 +1,23 @@
-import { authApi } from "@/shared/api";
-import { userState } from "@/shared/state/user";
 import { useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 import { useRecoilState } from "recoil";
+
+import { authApi } from "@/shared/api";
+import { userState } from "@/shared/state/user";
 
 const Kakao = () => {
   const code = new URL(document.URL).searchParams.get("code") as string;
   const [user, setUser] = useRecoilState(userState);
   const navigate = useNavigate();
 
-  const getToken = async () => {
+  const kakaoLogin = async () => {
     const token: string = await authApi.getKakaoToken(code);
     setUser({ ...user, token: token });
     navigate("/");
   };
 
   useEffect(() => {
-    getToken();
+    kakaoLogin();
   }, []);
 
   return <>Loading...</>;

--- a/src/components/common/AppLayout.tsx
+++ b/src/components/common/AppLayout.tsx
@@ -1,4 +1,5 @@
 import styled from "styled-components";
+
 import { media } from "@/styles/theme";
 
 const AppLayout = ({ children }: { children: JSX.Element }) => {

--- a/src/components/common/index.ts
+++ b/src/components/common/index.ts
@@ -1,2 +1,2 @@
-export { default as DebugObserver } from "@/components/common/DebugObserver";
 export { default as AppLayout } from "@/components/common/AppLayout";
+export { default as DebugObserver } from "@/components/common/DebugObserver";

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,10 +1,5 @@
-import React from "react";
 import ReactDOM from "react-dom/client";
 
 import App from "@/App";
 
-ReactDOM.createRoot(document.getElementById("root")!).render(
-  <React.StrictMode>
-    <App />
-  </React.StrictMode>,
-);
+ReactDOM.createRoot(document.getElementById("root")!).render(<App />);

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
+
 import App from "@/App";
 
 ReactDOM.createRoot(document.getElementById("root")!).render(

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,5 +1,6 @@
-import { userState } from "@/shared/state/user";
 import { useRecoilState } from "recoil";
+
+import { userState } from "@/shared/state/user";
 
 const Home = () => {
   const [user, setUser] = useRecoilState(userState);

--- a/src/shared/api/authApi.ts
+++ b/src/shared/api/authApi.ts
@@ -1,5 +1,5 @@
-import { METHOD } from "@/shared/constants/index";
 import fetcher from "@/shared/api/fetcher";
+import { METHOD } from "@/shared/constants/index";
 
 const authApi = {
   getKakaoToken(code: string) {

--- a/src/shared/api/authApi.ts
+++ b/src/shared/api/authApi.ts
@@ -1,9 +1,22 @@
 import fetcher from "@/shared/api/fetcher";
-import { METHOD } from "@/shared/constants/index";
+import { METHOD, URL } from "@/shared/constants/index";
 
 const authApi = {
   getKakaoToken(code: string) {
-    return fetcher(METHOD.GET, `/auth/kakao?code=${code}`);
+    const data: any = {
+      grant_type: "authorization_code",
+      client_id: import.meta.env.VITE_REST_API_KEY,
+      redirect_uri: import.meta.env.VITE_REDIRECT_URI,
+      code: code,
+    };
+    const queryString: any = Object.keys(data)
+      .map((k) => encodeURIComponent(k) + "=" + encodeURI(data[k]))
+      .join("&");
+    return fetcher(METHOD.POST, URL.KAKAO_TOKEN, queryString, {
+      headers: {
+        "Content-type": "application/x-www-form-urlencoded;charset=utf-8",
+      },
+    });
   },
 };
 

--- a/src/shared/api/authApi.ts
+++ b/src/shared/api/authApi.ts
@@ -10,11 +10,18 @@ const authApi = {
       code: code,
     };
     const queryString: any = Object.keys(data)
-      .map((k) => encodeURIComponent(k) + "=" + encodeURI(data[k]))
+      .map((key) => encodeURIComponent(key) + "=" + encodeURI(data[key]))
       .join("&");
     return fetcher(METHOD.POST, URL.KAKAO_TOKEN, queryString, {
       headers: {
         "Content-type": "application/x-www-form-urlencoded;charset=utf-8",
+      },
+    });
+  },
+  getserviceToken(token: string) {
+    return fetcher(METHOD.GET, "auth/token", {
+      headers: {
+        Authorization: `Bearer ${token}`,
       },
     });
   },

--- a/src/shared/api/fetcher.ts
+++ b/src/shared/api/fetcher.ts
@@ -1,5 +1,6 @@
 import axios from "axios";
-import { METHOD, URL, MESSAGE } from "@/shared/constants/index";
+
+import { MESSAGE, METHOD, URL } from "@/shared/constants/index";
 
 axios.defaults.baseURL = URL.BASE;
 

--- a/src/shared/constants/index.ts
+++ b/src/shared/constants/index.ts
@@ -10,6 +10,7 @@ export const URL = Object.freeze({
   KAKAO_AUTH: `https://kauth.kakao.com/oauth/authorize?client_id=${
     import.meta.env.VITE_REST_API_KEY
   }&redirect_uri=${import.meta.env.VITE_REDIRECT_URI}&response_type=code`,
+  KAKAO_TOKEN: "https://kauth.kakao.com/oauth/token",
 });
 
 export const MESSAGE = Object.freeze({

--- a/src/styles/global-style.ts
+++ b/src/styles/global-style.ts
@@ -1,5 +1,6 @@
 import { createGlobalStyle } from "styled-components";
 import { reset } from "styled-reset";
+
 import { media } from "@/styles/theme";
 
 export const GlobalStyle = createGlobalStyle`

--- a/yarn.lock
+++ b/yarn.lock
@@ -1399,6 +1399,11 @@ eslint-plugin-react@^7.30.0:
     semver "^6.3.0"
     string.prototype.matchall "^4.0.7"
 
+eslint-plugin-simple-import-sort@^8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-simple-import-sort/-/eslint-plugin-simple-import-sort-8.0.0.tgz#9d9a2372b0606e999ea841b10458a370a6ccc160"
+  integrity sha512-bXgJQ+lqhtQBCuWY/FUWdB27j4+lqcvXv5rUARkzbeWLwea+S5eBZEQrhnO+WgX3ZoJHVj0cn943iyXwByHHQw==
+
 eslint-scope@^5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-5.1.1.tgz#e786e59a66cb92b3f6c1fb0d508aab174848f48c"


### PR DESCRIPTION
## 📋 Detail

- [x] 카카오 토큰 받아오기
- [x] 서비스 전용 토큰 받아오기
- [x] eslint-plugin-simple-import-sort 적용

## 📌 PR Point

- 클라이언트에서 카카오 토큰을 받아와 서버로 전송하는 방식으로 변경했습니다
- 카카오 토큰은 다음과 같이 `auth/token` 경로에 `GET` 요청 헤더로 전송합니다
```
  fetcher(METHOD.GET, "auth/token", {
    headers: {
      Authorization: `Bearer ${token}`,
    },
  });
```
- import/export 순서를 정렬하는 ESLint 플러그인을 적용했습니다

## 📚 Reference

- [REST API | Kakao Developers 문서](https://developers.kakao.com/docs/latest/ko/kakaologin/rest-api)
- [[React]카카오 REST API 로그인_TS](https://keeper.tistory.com/47)
- [kakao Login API - KOE010(401)](https://velog.io/@denmark-choco/kakao-Login-API-KOE010401)
- [useEffect(() => {},[]) 두번 실행 되는 문제 해결](https://velog.io/@hjs0522/useEffect-%EB%91%90%EB%B2%88-%EC%8B%A4%ED%96%89-%EB%90%98%EB%8A%94-%EB%AC%B8%EC%A0%9C-%ED%95%B4%EA%B2%B0)
