### PR TITLE
localStorage로 로그인 상태 관리

### DIFF
--- a/src/components/Router.tsx
+++ b/src/components/Router.tsx
@@ -12,13 +12,13 @@ const Router = () => {
   const [user, setUser] = useRecoilState(userState);
 
   useEffect(() => {
-    const checkToken = () => {
+    const checkLocalStorage = () => {
       setUser({ ...user, isLoggedIn: Boolean(localStorage.getItem("user")) });
     };
-    addEventListener("storage", checkToken);
-    checkToken();
+    addEventListener("storage", checkLocalStorage);
+    checkLocalStorage();
     return () => {
-      removeEventListener("storage", checkToken);
+      removeEventListener("storage", checkLocalStorage);
     };
   }, []);
 

--- a/src/components/Router.tsx
+++ b/src/components/Router.tsx
@@ -1,6 +1,6 @@
-import { lazy, Suspense } from "react";
+import { lazy, Suspense, useEffect } from "react";
 import { BrowserRouter, Navigate, Route, Routes } from "react-router-dom";
-import { useRecoilValue } from "recoil";
+import { useRecoilState } from "recoil";
 
 import { Kakao } from "@/components/auth";
 import { userState } from "@/shared/state/user";
@@ -9,13 +9,25 @@ const Home = lazy(() => import("@/pages/Home"));
 const Auth = lazy(() => import("@/pages/Auth"));
 
 const Router = () => {
-  const hasTokken = useRecoilValue(userState).token !== "";
+  const [user, setUser] = useRecoilState(userState);
+
+  useEffect(() => {
+    const checkToken = () => {
+      setUser({ ...user, isLoggedIn: Boolean(localStorage.getItem("user")) });
+    };
+    addEventListener("storage", checkToken);
+    checkToken();
+    return () => {
+      removeEventListener("storage", checkToken);
+    };
+  }, []);
+
   return (
     <BrowserRouter>
       <Suspense fallback={<></>}>
         <Routes>
-          <Route path='/' element={hasTokken ? <Home /> : <Auth />} />
-          <Route path='/auth/kakao/*' element={!hasTokken && <Kakao />}></Route>
+          <Route path='/' element={user.isLoggedIn ? <Home /> : <Auth />} />
+          <Route path='/auth/kakao/*' element={!user.isLoggedIn && <Kakao />}></Route>
           <Route path='*' element={<Navigate to='/' replace />} />
         </Routes>
       </Suspense>

--- a/src/components/auth/Kakao.tsx
+++ b/src/components/auth/Kakao.tsx
@@ -12,9 +12,11 @@ const Kakao = () => {
 
   const kakaoLogin = async () => {
     const kakaoToken = await authApi.getKakaoToken(code);
-    console.log(kakaoToken.access_token);
-    const serviceToken = await authApi.getserviceToken(kakaoToken.access_token);
-    setUser({ ...user, token: serviceToken });
+    const serviceToken = await authApi.getServiceToken(kakaoToken.access_token);
+    if (serviceToken) {
+      localStorage.setItem("user", JSON.stringify({ token: serviceToken }));
+      setUser({ ...user, isLoggedIn: true });
+    }
     navigate("/");
   };
 

--- a/src/components/auth/Kakao.tsx
+++ b/src/components/auth/Kakao.tsx
@@ -6,16 +6,18 @@ import { authApi } from "@/shared/api";
 import { userState } from "@/shared/state/user";
 
 const Kakao = () => {
-  const code = new URL(document.URL).searchParams.get("code") as string;
+  const code = new URL(document.URL).searchParams.get("code");
   const [user, setUser] = useRecoilState(userState);
   const navigate = useNavigate();
 
   const kakaoLogin = async () => {
-    const kakaoToken = await authApi.getKakaoToken(code);
-    const serviceToken = await authApi.getServiceToken(kakaoToken.access_token);
-    if (serviceToken) {
-      localStorage.setItem("user", JSON.stringify({ token: serviceToken }));
-      setUser({ ...user, isLoggedIn: true });
+    if (typeof code === "string") {
+      const kakaoToken = await authApi.getKakaoToken(code);
+      const serviceToken = await authApi.getServiceToken(kakaoToken.access_token);
+      if (serviceToken) {
+        localStorage.setItem("user", JSON.stringify({ token: serviceToken }));
+        setUser({ ...user, isLoggedIn: true });
+      }
     }
     navigate("/");
   };

--- a/src/components/auth/Kakao.tsx
+++ b/src/components/auth/Kakao.tsx
@@ -13,9 +13,9 @@ const Kakao = () => {
   const kakaoLogin = async () => {
     if (typeof code === "string") {
       const kakaoToken = await authApi.getKakaoToken(code);
-      const serviceToken = await authApi.getServiceToken(kakaoToken.access_token);
-      if (serviceToken) {
-        localStorage.setItem("user", JSON.stringify({ token: serviceToken }));
+      const res = await authApi.sendKakaoToken(kakaoToken.access_token);
+      if (res.status === 200 || res.status === 201) {
+        localStorage.setItem("user", JSON.stringify({}));
         setUser({ ...user, isLoggedIn: true });
       }
     }

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -4,7 +4,13 @@ import { userState } from "@/shared/state/user";
 
 const Home = () => {
   const [user, setUser] = useRecoilState(userState);
-  return <button onClick={() => setUser({ ...user, token: "" })}>Logout</button>;
+
+  const logout = () => {
+    localStorage.removeItem("user");
+    setUser({ ...user, isLoggedIn: false });
+  };
+
+  return <button onClick={() => logout()}>Logout</button>;
 };
 
 export default Home;

--- a/src/shared/api/authApi.ts
+++ b/src/shared/api/authApi.ts
@@ -18,7 +18,7 @@ const authApi = {
       },
     });
   },
-  getServiceToken(token: string) {
+  sendKakaoToken(token: string) {
     return fetcher(METHOD.GET, "auth/token", {
       headers: {
         Authorization: `Bearer ${token}`,

--- a/src/shared/api/authApi.ts
+++ b/src/shared/api/authApi.ts
@@ -18,7 +18,7 @@ const authApi = {
       },
     });
   },
-  getserviceToken(token: string) {
+  getServiceToken(token: string) {
     return fetcher(METHOD.GET, "auth/token", {
       headers: {
         Authorization: `Bearer ${token}`,

--- a/src/shared/constants/index.ts
+++ b/src/shared/constants/index.ts
@@ -6,7 +6,7 @@ export const METHOD = {
 } as const;
 
 export const URL = Object.freeze({
-  BASE: "http://localhost:8000",
+  BASE: `${import.meta.env.BASE_URL}`,
   KAKAO_AUTH: `https://kauth.kakao.com/oauth/authorize?client_id=${
     import.meta.env.VITE_REST_API_KEY
   }&redirect_uri=${import.meta.env.VITE_REDIRECT_URI}&response_type=code`,

--- a/src/shared/state/user.ts
+++ b/src/shared/state/user.ts
@@ -2,5 +2,5 @@ import { atom } from "recoil";
 
 export const userState = atom({
   key: "userState",
-  default: { token: "" },
+  default: { isLoggedIn: false },
 });


### PR DESCRIPTION
## 📋 Detail

- [x] localStorage로 로그인 상태 관리 (임시)

## 📌 PR Point

- 스프링 시큐리티가 URL 직접 접근을 막아주기때문에 (`GET` 요청 헤더로 넣어주려 했던) 서비스 전용 토큰을 반환받지 않고 로그인 성공 여부만 먼저 저장하도록 변경했습니다
- `sendKakaoToken` API 요청이 성공한다면 `localStorage`에 `user`가 키 값인 빈 객체를 넣어 종합정보시스템에 연동하지 않은 유저의 로그인 상태를 유지합니다
- `checkLocalStorage` 함수는  라우터에서 `localStorage`의 모든 변화를 감지하고 `user`가 키 값인 데이터 존재 여부에 따라 임시로 유저의 로그인 상태를 관리합니다
  - 로그아웃 로직은 `localStorage`에서 `user`가 키 값인 데이터 삭제입니다
  - 전역 상태 관리를 위해 유저의 로그인 상태는 `Recoil`과 항상 동기화됩니다


## 📚 Reference

- [useEffect does not listen for localStorage](https://stackoverflow.com/questions/61178240/useeffect-does-not-listen-for-localstorage)
