### PR TITLE
에러 핸들링 구조 변경

### DIFF
--- a/src/components/Router.tsx
+++ b/src/components/Router.tsx
@@ -3,6 +3,7 @@ import { BrowserRouter, Navigate, Route, Routes } from "react-router-dom";
 import { useRecoilState } from "recoil";
 
 import { Kakao } from "@/components/auth";
+import { USER } from "@/shared/constants/index";
 import { userState } from "@/shared/state/user";
 
 const Home = lazy(() => import("@/pages/Home"));
@@ -13,7 +14,7 @@ const Router = () => {
 
   useEffect(() => {
     const checkLocalStorage = () => {
-      setUser({ ...user, isLoggedIn: Boolean(localStorage.getItem("user")) });
+      setUser({ ...user, isLoggedIn: Boolean(localStorage.getItem(USER)) });
     };
     addEventListener("storage", checkLocalStorage);
     checkLocalStorage();

--- a/src/components/auth/Kakao.tsx
+++ b/src/components/auth/Kakao.tsx
@@ -13,9 +13,9 @@ const Kakao = () => {
   const kakaoLogin = async () => {
     if (typeof code === "string") {
       const kakaoToken = await authApi.getKakaoToken(code);
-      const res = await authApi.sendKakaoToken(kakaoToken.access_token);
-      if (res.status === 200 || res.status === 201) {
-        localStorage.setItem("user", JSON.stringify({}));
+      const serviceToken = await authApi.getServiceToken(kakaoToken.access_token);
+      if (serviceToken.token) {
+        localStorage.setItem("user", JSON.stringify({ token: serviceToken.token }));
         setUser({ ...user, isLoggedIn: true });
       }
     }

--- a/src/components/auth/Kakao.tsx
+++ b/src/components/auth/Kakao.tsx
@@ -3,6 +3,7 @@ import { useNavigate } from "react-router-dom";
 import { useRecoilState } from "recoil";
 
 import { authApi } from "@/shared/api";
+import { USER } from "@/shared/constants/index";
 import { userState } from "@/shared/state/user";
 
 const Kakao = () => {
@@ -15,7 +16,7 @@ const Kakao = () => {
       const kakaoToken = await authApi.getKakaoToken(code);
       const serviceToken = await authApi.getServiceToken(kakaoToken.access_token);
       if (serviceToken.token) {
-        localStorage.setItem("user", JSON.stringify({ token: serviceToken.token }));
+        localStorage.setItem(USER, JSON.stringify({ token: serviceToken.token }));
         setUser({ ...user, isLoggedIn: true });
       }
     }

--- a/src/components/auth/Kakao.tsx
+++ b/src/components/auth/Kakao.tsx
@@ -3,7 +3,7 @@ import { useNavigate } from "react-router-dom";
 import { useRecoilState } from "recoil";
 
 import { authApi } from "@/shared/api";
-import { USER } from "@/shared/constants/index";
+import { ERROR, USER } from "@/shared/constants/index";
 import { userState } from "@/shared/state/user";
 
 const Kakao = () => {
@@ -12,14 +12,16 @@ const Kakao = () => {
   const navigate = useNavigate();
 
   const kakaoLogin = async () => {
-    if (typeof code === "string") {
-      const kakaoToken = await authApi.getKakaoToken(code);
-      const serviceToken = await authApi.getServiceToken(kakaoToken.access_token);
-      if (serviceToken.token) {
+    if (code) {
+      try {
+        const kakaoToken = await authApi.getKakaoToken(code);
+        const serviceToken = await authApi.getServiceToken(kakaoToken);
         localStorage.setItem(USER, JSON.stringify({ token: serviceToken.token }));
         setUser({ ...user, isLoggedIn: true });
+      } catch (error) {
+        alert(`${error}`);
       }
-    }
+    } else alert(ERROR.KAKAO_CODE);
     navigate("/");
   };
 

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,12 +1,13 @@
 import { useRecoilState } from "recoil";
 
+import { USER } from "@/shared/constants/index";
 import { userState } from "@/shared/state/user";
 
 const Home = () => {
   const [user, setUser] = useRecoilState(userState);
 
   const logout = () => {
-    localStorage.removeItem("user");
+    localStorage.removeItem(USER);
     setUser({ ...user, isLoggedIn: false });
   };
 

--- a/src/shared/api/authApi.ts
+++ b/src/shared/api/authApi.ts
@@ -18,7 +18,7 @@ const authApi = {
       },
     });
   },
-  sendKakaoToken(token: string) {
+  getServiceToken(token: string) {
     return fetcher(METHOD.GET, "auth/token", {
       headers: {
         Authorization: `Bearer ${token}`,

--- a/src/shared/api/authApi.ts
+++ b/src/shared/api/authApi.ts
@@ -1,8 +1,8 @@
 import fetcher from "@/shared/api/fetcher";
-import { METHOD, URL } from "@/shared/constants/index";
+import { ERROR, METHOD, URL } from "@/shared/constants/index";
 
 const authApi = {
-  getKakaoToken(code: string) {
+  async getKakaoToken(code: string) {
     const data: any = {
       grant_type: "authorization_code",
       client_id: import.meta.env.VITE_REST_API_KEY,
@@ -12,18 +12,28 @@ const authApi = {
     const queryString: any = Object.keys(data)
       .map((key) => encodeURIComponent(key) + "=" + encodeURI(data[key]))
       .join("&");
-    return fetcher(METHOD.POST, URL.KAKAO_TOKEN, queryString, {
-      headers: {
-        "Content-type": "application/x-www-form-urlencoded;charset=utf-8",
-      },
-    });
+    try {
+      const res = await fetcher(METHOD.POST, URL.KAKAO_TOKEN, queryString, {
+        headers: {
+          "Content-type": "application/x-www-form-urlencoded;charset=utf-8",
+        },
+      });
+      return res.access_token;
+    } catch {
+      throw ERROR.KAKAO_TOKEN;
+    }
   },
-  getServiceToken(token: string) {
-    return fetcher(METHOD.GET, "auth/token", {
-      headers: {
-        Authorization: `Bearer ${token}`,
-      },
-    });
+  async getServiceToken(token: string) {
+    try {
+      const res = await fetcher(METHOD.GET, "auth/token", {
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
+      });
+      return res.token;
+    } catch {
+      throw ERROR.API;
+    }
   },
 };
 

--- a/src/shared/api/fetcher.ts
+++ b/src/shared/api/fetcher.ts
@@ -1,6 +1,6 @@
 import axios from "axios";
 
-import { MESSAGE, METHOD, URL } from "@/shared/constants/index";
+import { METHOD, URL } from "@/shared/constants/index";
 
 axios.defaults.baseURL = URL.BASE;
 
@@ -9,12 +9,8 @@ const fetcher = async (
   url: string,
   ...rest: { [key: string]: any }[]
 ) => {
-  try {
-    const res = await axios[method](url, ...rest);
-    return res.data;
-  } catch (error: any) {
-    alert(`${MESSAGE.ALERT_API} (${error.message})`);
-  }
+  const res = await axios[method](url, ...rest);
+  return res.data;
 };
 
 export default fetcher;

--- a/src/shared/constants/index.ts
+++ b/src/shared/constants/index.ts
@@ -1,3 +1,5 @@
+export const USER = "user";
+
 export const METHOD = {
   GET: "get",
   POST: "post",

--- a/src/shared/constants/index.ts
+++ b/src/shared/constants/index.ts
@@ -15,6 +15,8 @@ export const URL = Object.freeze({
   KAKAO_TOKEN: "https://kauth.kakao.com/oauth/token",
 });
 
-export const MESSAGE = Object.freeze({
-  ALERT_API: "에러가 발생했습니다.",
+export const ERROR = Object.freeze({
+  KAKAO_CODE: "카카오 인가코드가 유효하지 않습니다.",
+  KAKAO_TOKEN: "카카오 서버와의 통신에 실패했습니다.",
+  API: "API 서버와의 통신에 실패했습니다.",
 });


### PR DESCRIPTION
## ⛓ Related Issues

- close #12 

## 📋 Detail

- [x] API 객체에서 에러 핸들링
- [x] 다시 서비스 토큰 받는 방식으로 변경

## 📌 PR Point

- API 객체에서 `try...catch` 구문으로 상황에 맞는 에러 메시지를 `throw`하도록 리팩토링했습니다
- API 통신을 위해 다시 서비스 토큰을 받아오는 방식으로 변경했습니다
