### PR TITLE
getServiceToken 요청 메서드 POST로 변경 및 값 헤더로 받기

### DIFF
--- a/src/api/authApi.ts
+++ b/src/api/authApi.ts
@@ -18,19 +18,19 @@ const authApi = {
           "Content-type": "application/x-www-form-urlencoded;charset=utf-8",
         },
       });
-      return res.access_token;
+      return res.data.access_token;
     } catch {
       throw ERROR.KAKAO_TOKEN;
     }
   },
   async getServiceToken(token: string) {
     try {
-      const res = await fetcher(METHOD.GET, "login/oauth2/kakao", {
+      const res = await fetcher(METHOD.POST, "login/oauth2/kakao", {
         headers: {
           Authorization: `Bearer ${token}`,
         },
       });
-      return res.token.jwt;
+      return res.headers["Authorization"].split(" ")[1];
     } catch {
       throw ERROR.API;
     }
@@ -42,7 +42,7 @@ const authApi = {
           Authorization: `Bearer ${token}`,
         },
       });
-      return res.status;
+      return res.data.status;
     } catch {
       throw ERROR.TOKEN;
     }

--- a/src/api/fetcher.ts
+++ b/src/api/fetcher.ts
@@ -10,7 +10,7 @@ const fetcher = async (
   ...rest: { [key: string]: any }[]
 ) => {
   const res = await axios[method](url, ...rest);
-  return res.data;
+  return res;
 };
 
 export default fetcher;

--- a/src/api/infoApi.ts
+++ b/src/api/infoApi.ts
@@ -18,7 +18,7 @@ const infoApi = {
           },
         },
       );
-      return res;
+      return res.data;
     } catch {
       throw ERROR.INFO;
     }

--- a/src/components/info/InfoForm.tsx
+++ b/src/components/info/InfoForm.tsx
@@ -61,7 +61,7 @@ const Input = styled.input`
   font-family: "Noto Sans KR";
   font-weight: bold;
   font-size: 16px;
-  border-radius: 20px;
+  border-radius: 15px;
   width: 245px;
   height: 20px;
   padding: 15px;


### PR DESCRIPTION
## 📋 Detail

- [x] getServiceToken 요청 메서드 POST로 변경 및 값 헤더로 받기

## 📌 PR Point

- `getServiceToken`의 요청 메서드를 `GET`에서 `POST`로 변경했습니다
- `JWT 토큰`이 응답 헤더에 `Authorization: "Bearer ${token}"`으로 들어온다고 가정하고 로직을 수정했습니다

## 📚 Reference

- [Response Schema | Axios Docs](https://axios-http.com/docs/res_schema)
