### PR TITLE
서버에 인가코드 넘겨주는 방식으로 변경

### DIFF
--- a/src/api/authApi.ts
+++ b/src/api/authApi.ts
@@ -1,34 +1,11 @@
 import fetcher from "@/api/fetcher";
-import { ERROR, METHOD, URL } from "@/constants";
+import { ERROR, METHOD } from "@/constants";
 
 const authApi = {
-  async getKakaoToken(code: string) {
-    const data: any = {
-      grant_type: "authorization_code",
-      client_id: import.meta.env.VITE_REST_API_KEY,
-      redirect_uri: import.meta.env.VITE_REDIRECT_URI,
-      code,
-    };
-    const queryString: any = Object.keys(data)
-      .map((key) => encodeURIComponent(key) + "=" + encodeURI(data[key]))
-      .join("&");
+  async getServiceToken(code: string) {
     try {
-      const res = await fetcher(METHOD.POST, URL.KAKAO_TOKEN, queryString, {
-        headers: {
-          "Content-type": "application/x-www-form-urlencoded;charset=utf-8",
-        },
-      });
-      return res.data.access_token;
-    } catch {
-      throw ERROR.KAKAO_TOKEN;
-    }
-  },
-  async getServiceToken(token: string) {
-    try {
-      const res = await fetcher(METHOD.POST, "login/oauth2/kakao", {
-        headers: {
-          Authorization: `Bearer ${token}`,
-        },
+      const res = await fetcher(METHOD.GET, "login/oauth2/kakao", {
+        params: { code },
       });
       return res.headers["Authorization"].split(" ")[1];
     } catch {

--- a/src/api/authApi.ts
+++ b/src/api/authApi.ts
@@ -4,10 +4,10 @@ import { ERROR, METHOD } from "@/constants";
 const authApi = {
   async getServiceToken(code: string) {
     try {
-      const res = await fetcher(METHOD.GET, "login/oauth2/kakao", {
+      const res = await fetcher(METHOD.GET, "v1/auth/kakao", {
         params: { code },
       });
-      return res.headers["Authorization"].split(" ")[1];
+      return res.headers["authorization"].split(" ")[1];
     } catch {
       throw ERROR.API;
     }

--- a/src/components/auth/Kakao.tsx
+++ b/src/components/auth/Kakao.tsx
@@ -15,8 +15,7 @@ const Kakao = () => {
   const kakaoLogin = async () => {
     if (code) {
       try {
-        const kakaoToken = await authApi.getKakaoToken(code);
-        const serviceToken = await authApi.getServiceToken(kakaoToken);
+        const serviceToken = await authApi.getServiceToken(code);
         localStorage.setItem(TOKEN, serviceToken);
         setUser({ ...user, isLoggedIn: true });
       } catch (error) {

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -19,12 +19,10 @@ export const URL = Object.freeze({
   KAKAO_AUTH: `https://kauth.kakao.com/oauth/authorize?client_id=${
     import.meta.env.VITE_REST_API_KEY
   }&redirect_uri=${import.meta.env.VITE_REDIRECT_URI}&response_type=code`,
-  KAKAO_TOKEN: "https://kauth.kakao.com/oauth/token",
 });
 
 export const ERROR = Object.freeze({
   KAKAO_CODE: "카카오 인가코드가 유효하지 않습니다.",
-  KAKAO_TOKEN: "카카오 서버와의 통신에 실패했습니다.",
   API: "API 서버와의 통신에 실패했습니다.",
   INFO: "종합정보시스템 연동에 실패했습니다.",
   TOKEN: "엑세스 토큰 인증에 실패했습니다.",


### PR DESCRIPTION
## 📋 Detail

- [x] 서버에 인가코드 넘겨주는 방식으로 변경

## 📌 PR Point

- 카카오 인가코드를 `GET` 요청 쿼리 파라미터에 넣어서 서버에 전달합니다
- 응답 `headers`에 `authorization: Bearer $token`값을 받아 `localStorage`에 저장합니다
- 토큰 인증 로직을 `리프레시 토큰`을 활용하는 방식으로 변경할 필요가 있습니다