### PR TITLE
리프레시 토큰을 활용한 JWT 유효성 검증 로직 구현

### DIFF
--- a/src/api/authApi.ts
+++ b/src/api/authApi.ts
@@ -14,12 +14,12 @@ const authApi = {
   },
   async isTokenValid(token: string) {
     try {
-      const res = await fetcher(METHOD.GET, "api/token/check", {
+      const res = await fetcher(METHOD.GET, "v1/auth/token", {
         headers: {
           Authorization: `Bearer ${token}`,
         },
       });
-      return res.data.status;
+      return res;
     } catch {
       throw ERROR.TOKEN;
     }

--- a/src/components/Router.tsx
+++ b/src/components/Router.tsx
@@ -18,15 +18,28 @@ const Router = () => {
 
   const checkStorageToken = async () => {
     const token = localStorage.getItem(TOKEN);
-    if (!token) setUser({ ...user, isLoggedIn: false });
-    else {
-      try {
-        const status = await authApi.isTokenValid(token);
-        status === "OK" ? setUser({ ...user, isLoggedIn: true }) : logout();
-      } catch (error) {
-        logout();
-        alert(error);
+    if (!token) return setUser({ ...user, isLoggedIn: false });
+
+    try {
+      const res = await authApi.isTokenValid(token);
+
+      switch (res.data.status) {
+        case "OK":
+          setUser({ ...user, isLoggedIn: true });
+          break;
+        case "RENEW": {
+          const serviceToken = res.headers["authorization"].split(" ")[1];
+          localStorage.setItem(TOKEN, serviceToken);
+          setUser({ ...user, isLoggedIn: true });
+          break;
+        }
+        case "EXPIRED":
+          logout();
+          break;
       }
+    } catch (error) {
+      logout();
+      alert(error);
     }
   };
 


### PR DESCRIPTION
## ⛓ Related Issues

- close #3

## 📋 Detail

- [x] 리프레시 토큰을 활용한 JWT 유효성 검증 로직 구현

## 📌 PR Point

- 서버의 리프레시 토큰을 활용해 JWT 유효성 검증 로직 구현했습니다
- `JWT 토큰의 유효기간`과 `리프레시 토큰의 유효기간`에 따라 나올 수 있는 경우는 다음과 같습니다

```
1. 클라이언트에서 로컬스토리지에 저장된 JWT 토큰을 GET 요청 헤더에 넣어서 전달
2. 서버에서 JWT 토큰의 유효기간을 확인

A. 유효기간이 지나지 않은 경우 응답을 보내 로그인 상태 유지 (OK)
B. 유효기간이 지난 경우 서버의 리프레시 토큰 확인

B - 1. 서버의 리프레시 토큰이 유효한 경우 응답으로 새로운 JWT 토큰 반환 및 로그인 상태 유지 (RENEW)
B - 2. 서버의 리프레시 토큰이 유효하지 않은 경우 로그아웃 (EXPIRED)
```

- `v1/auth/token` 경로의 구체적인 `axios` 응답은 다음과 같습니다

```
{
  // `data`는 서버가 제공한 응답(데이터)입니다.
  data: {
    status: "OK",
  },
};


{
  data: {
    status: "RENEW",
  },

  // `headers` 서버가 응답 한 헤더는 모든 헤더 이름이 소문자로 제공됩니다.
  headers: {
    Authorization: `Bearer ${token}`,
  },
};

{
  data: {
    status: "EXPIRED",
  },
};
```